### PR TITLE
Update run_train_sparse_second.sh

### DIFF
--- a/runs/run_train_sparse_second.sh
+++ b/runs/run_train_sparse_second.sh
@@ -24,7 +24,7 @@ echo "train_batch_size: $train_batch_size"
 export CUDA_DEVICE_ORDER="PCI_BUS_ID"
 python -m torch.distributed.launch \
  --nproc_per_node ${n_GPU} \
- --master_port $RANDOM../run_classification.py \
+ --master_port $RANDOM ../run_classification.py \
  --model_name_or_path ${model_name} \
  --do_eval \
  --output_dir ../temp/${model_name}/sparse_second/${task}_l${lower}_u${upper}/bs${train_batch_size}_lr${write_lr}_seed${seed} \


### PR DESCRIPTION
The lack of spacing resulted in an incorrect port number making the script unusable. This change should fix it.